### PR TITLE
Add line to save compiled estimates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/code/ihme_versions.R
+++ b/code/ihme_versions.R
@@ -36,3 +36,5 @@ d[,date_form:=as.Date(date)]
 ## clean up variables duplicated through changing of formats
 d[,c("location"):=NULL]
 
+## Write the results to an output/ folder
+write.csv(d, file="output/compiled_estimates.csv",row.names = F)


### PR DESCRIPTION
Hey Matt, 

Not sure if you want to collaborate a bit across repos, but I figured it would be helpful to save the compiled estimates to a file so they can be loaded live into visualizations off the web (e.g., https://observablehq.com/@mkfreeman/projected-covid-19-deaths). Happy to use a different file structure, but assuming that you'll continue updating the data as it gets released (hopefully // please...?), it would be super helpful to continue writing to the compiled results.  